### PR TITLE
Set min sci-kit learn version to >= 1.7

### DIFF
--- a/DENV-SEROTYPE-IMPUTATION.yml
+++ b/DENV-SEROTYPE-IMPUTATION.yml
@@ -17,4 +17,4 @@ dependencies:
   - pyarrow
   - tslearn
   - seaborn
-  - scikit-learn
+  - scikit-learn>=1.7


### PR DESCRIPTION
To enable normalized stress in MDS.